### PR TITLE
switch Docker baseimage to nvidia/cuda-9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM ubuntu:artful-20180412
-#FROM ubuntu:bionic-20180410
+FROM nvidia/cuda:9.2-devel-ubuntu18.04
+
+# CUDA version must be compatible with driver version of host:
+# CUDA Toolkit          Linux x86_64 Driver Version
+# CUDA 10.0 (10.0.130)  >= 410.48
+# CUDA 9.2 (9.2.88)     >= 396.26
+# CUDA 9.1 (9.1.85)     >= 390.46
+# CUDA 9.0 (9.0.76)     >= 384.81
+# CUDA 8.0 (8.0.61 GA2) >= 375.26
+# CUDA 8.0 (8.0.44)     >= 367.48
+# CUDA 7.5 (7.5.16)     >= 352.31
+# CUDA 7.0 (7.0.28)     >= 346.46
+#
+# As of 2019-02-26, driver version 396.37 is suggested
 
 LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
+LABEL maintainer_other "Christopher Tomkins-Tinch <tomkinsc@broadinstitute.org>"
 
 COPY install-*.sh /opt/docker/
 
@@ -13,9 +26,13 @@ RUN /opt/docker/install-apt_packages.sh
 
 # Set default locale to en_US.UTF-8
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"
+ENV LD_LIBRARY_PATH /usr/local/lib:${LD_LIBRARY_PATH}
+ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs:${LIBRARY_PATH}
 
 RUN /opt/docker/install-beagle.sh
 
 RUN /opt/docker/install-beast.sh
+
+ENV BEAST="/usr/local"
 
 ENTRYPOINT ["/bin/bash"]

--- a/dsub_beast.sh
+++ b/dsub_beast.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This is only a demonstration of how to run beast via dsub. 
+# The accelerator (GPU) type and count should be set according to 
+# the size of the data and number of partitions.
+
+# --accelerator-count should scale with number of partitions in data
+# --nvidia-driver-version must match compatible CUDA version
+# 
+
+function print_usage(){
+    echo "Usage: $(basename $SCRIPT) gs://path/to/in.xml gcp-project-name"
+}
+
+if [ $# -eq 0 ]; then
+    print_usage
+    exit 1
+fi
+
+IN_XML="$1"
+OUT_BUCKET="$(dirname $1)"
+GCP_PROJECT="$2"
+DOCKER_IMAGE="quay.io/broadinstitute/beast-beagle-cuda"
+
+dsub \
+  --provider=google-v2 \
+  --project "${GCP_PROJECT}" \
+  --zone "us*" \
+  --accelerator-type "nvidia-tesla-k80" \
+  --nvidia-driver-version "396.37" \
+  --accelerator-count 1 \
+  --image "${DOCKER_IMAGE}" \
+  --input "INPUT_FILE=${IN_XML}" \
+  --output "OUTPUT_FILES=${OUT_BUCKET}/*" \
+  --logging "${OUT_BUCKET}" \
+  --script 'run_beast.sh' \
+  --boot-disk-size 30 \
+  --wait

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -26,8 +26,6 @@ ln -s /usr/bin/g++-6 /usr/local/cuda/bin/g++
 
 # Auto-detect platform
 DEBIAN_PLATFORM="$(lsb_release -c -s)"
-#override for google cloud sdk
-DEBIAN_PLATFORM="artful"
 echo "Debian platform: $DEBIAN_PLATFORM"
 
 # Add source for gcloud sdk

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -18,20 +18,11 @@ apt-get install -y -qq \
 	libtool autoconf g++-6 gcc-6 \
 	ant \
 	openjdk-8-jre openjdk-8-jdk
+    #
 
 mkdir -p /usr/local/cuda/bin
 ln -s /usr/bin/gcc-6 /usr/local/cuda/bin/gcc
 ln -s /usr/bin/g++-6 /usr/local/cuda/bin/g++
-
-# Add CUDA Toolkit
-_DEB_NAME=cuda-repo-ubuntu1704_9.1.85-1_amd64.deb
-wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1704/x86_64/$_DEB_NAME
-dpkg -i $_DEB_NAME
-rm $_DEB_NAME
-apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1704/x86_64/7fa2af80.pub
-apt-get update
-apt-get install -y -qq --no-install-recommends cuda-9-1
-
 
 # Auto-detect platform
 DEBIAN_PLATFORM="$(lsb_release -c -s)"
@@ -50,6 +41,6 @@ apt-get install -y -qq --no-install-recommends \
 
 # Upgrade and clean
 apt-get upgrade -y
-apt-get clean
+apt-get clean -y
 
 locale-gen en_US.UTF-8

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -1,21 +1,18 @@
 #!/bin/bash
 
+set -e -o pipefail
+
 cd /opt/docker
 
-git clone https://github.com/beagle-dev/beagle-lib.git
+# beagle 3.1.2, known working with beast 1.10.4
+git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
 cd beagle-lib
-## Nov 2017. Future commits break things?
-#git checkout bcd2bf1a0b17703e8e24d56e0f1b5b4967470b8b
 
 ./autogen.sh
-./configure --prefix=/usr/local
+./configure --disable-sse --disable-march-native --prefix=/usr/local
 
 make
-
+make install
 make check
 
-make install
-ldconfig
-
-examples/genomictest/genomictest
-examples/tinytest/tinytest
+ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -16,3 +16,6 @@ make install
 make check
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib
+
+examples/synthetictest/synthetictest
+examples/tinytest/tinytest

--- a/install-beast.sh
+++ b/install-beast.sh
@@ -1,26 +1,10 @@
 #!/bin/bash
 
-## the section below pulls a named version
+wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v1.10.4/BEASTv1.10.4.tgz
+tar -xzpf BEASTv1.10.4.tgz
+rm BEASTv1.10.4.tgz
 
-wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v1.10.1/BEASTv1.10.1.tgz
-tar -xzpf BEASTv1.10.1.tgz
-rm BEASTv1.10.1.tgz
+mv BEASTv1.10.4/bin/* /usr/local/bin
+mv BEASTv1.10.4/lib/* /usr/local/lib
 
-mv BEASTv1.10.1/bin/* /usr/local/bin
-mv BEASTv1.10.1/lib/* /usr/local/lib
-
-## the section below pulls the latest HEAD from master
-#
-#cd /opt/docker
-#
-#git clone https://github.com/beast-dev/beast-mcmc.git
-#cd beast-mcmc
-#
-#ant dist
-#
-#mv build/dist/* /usr/local/lib
-#mv release/Linux/lib/* /usr/local/lib
-#mv release/Linux/scripts/* /usr/local/bin
-
-## however it got installed, let's test that it works:
 beast -beagle_info

--- a/run_beast.sh
+++ b/run_beast.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script is intended to invoke beast within a Docker container
+# running on the Google Cloud Platform via the Pipelines API / dsub
+
+IN_DIR=$(dirname "${INPUT_FILE}")
+OUT_DIR=$(dirname "${OUTPUT_FILES}")
+OUTPUT_PREFIX=$(basename "${INPUT_FILE}" .xml)
+
+pwd 
+cd $OUT_DIR
+beast -beagle_info > "${OUTPUT_PREFIX}.out"
+pwd 
+beast -beagle_GPU -beagle_cuda -beagle_double -beagle_scaling always -beagle_order 1 ${INPUT_FILE} >> "${OUTPUT_PREFIX}.out"
+ls 

--- a/run_beast.sh
+++ b/run_beast.sh
@@ -6,10 +6,19 @@
 IN_DIR=$(dirname "${INPUT_FILE}")
 OUT_DIR=$(dirname "${OUTPUT_FILES}")
 OUTPUT_PREFIX=$(basename "${INPUT_FILE}" .xml)
+if [ -z "${BEAGLE_ORDER}" ]; then
+  BEAGLE_ORDER=1 # run on first GPU only if BEAGLE_ORDER is not set
+fi
+
+if [ -z "${INPUT_FILE}" ]; then
+    echo "Usage: $(basename $0) [beagle_order]"
+    echo '       The input xml must be passed via INPUT_FILE=/path/to/beauti_generated_input.xml'
+    exit 1
+fi
 
 pwd 
 cd $OUT_DIR
 beast -beagle_info > "${OUTPUT_PREFIX}.out"
 pwd 
-beast -beagle_GPU -beagle_cuda -beagle_double -beagle_scaling always -beagle_order 1 ${INPUT_FILE} >> "${OUTPUT_PREFIX}.out"
+beast -beagle_GPU -beagle_cuda -beagle_double -beagle_scaling always -beagle_order ${BEAGLE_ORDER} ${INPUT_FILE} >> "${OUTPUT_PREFIX}.out"
 ls 


### PR DESCRIPTION
This switches the Docker base image to one provided by NVIDIA (based on ubuntu18.04), so we are not actually redistributing their drivers, just layering on top of something they have already released with a working cuda install. This has cuda 9.2, which requires NVIDIA driver version `>=396.26` on the Docker host (`396.37` is the most recent version as of 2019-02-26). 

This PR also includes an example script, `dsub_beast.sh`, to run beast from the generated image on the Google Cloud Platform via [`dsub`](https://github.com/DataBiosphere/dsub).

SSE and native extensions are also disabled for CPU executor compatibility across Docker hosts.