### PR TITLE
update dependencies for Ubuntu 20.04, and migrate beagle build to CMake. Update BEAST to  BEASTv.1.10.5pre_thorney_v0.1.1 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM nvidia/cuda:10.0-devel-ubuntu18.04
+FROM nvidia/cuda:11.4.2-devel-ubuntu20.04
 
 # CUDA version must be compatible with driver version of host:
+# via https://docs.nvidia.com/deploy/cuda-compatibility/#minor-version-compatibility
+#
 # CUDA Toolkit          Linux x86_64 Driver Version
+#--------------------------------------------------
+# CUDA 11.x             >= 450.80.02
+# CUDA 10.2             >= 440.33
+# CUDA 10.1             >= 418.39
 # CUDA 10.0 (10.0.130)  >= 410.48
 # CUDA 9.2 (9.2.88)     >= 396.26
 # CUDA 9.1 (9.1.85)     >= 390.46

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:11.0.3-devel-ubuntu20.04
 
 # CUDA version must be compatible with driver version of host:
-#      via: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+#       via: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
 #
 # Note: The container-optimized OS (COS) images used to host dsub docker containers
 #       have NVIDIA driver versions that lag current versions. The nvidia/cuda baseimage

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM nvidia/cuda:11.0.3-devel-ubuntu20.04
 #                https://cloud.google.com/container-optimized-os/docs/release-notes
 #
 # CUDA Toolkit          Linux x86_64 Driver Version
-#--------------------------------------------------
+# -------------------------------------------------
 # CUDA 11.5.1           >= 495.29.05
 # CUDA 11.4.3           >= 470.82.01
 # CUDA 11.4.2           >= 470.57.02

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.4.2-devel-ubuntu20.04
+FROM nvidia/cuda:11.0.3-devel-ubuntu20.04
 
 # CUDA version must be compatible with driver version of host:
 #      via: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
@@ -7,10 +7,10 @@ FROM nvidia/cuda:11.4.2-devel-ubuntu20.04
 #
 # CUDA Toolkit          Linux x86_64 Driver Version
 #--------------------------------------------------
-# CUDA 11.5             >= 495.29.05
-# CUDA 11.4             >= 470.82.01
-# CUDA 11.4             >= 470.57.02
-# CUDA 11.4             >= 470.57.02
+# CUDA 11.5.1           >= 495.29.05
+# CUDA 11.4.3           >= 470.82.01
+# CUDA 11.4.2           >= 470.57.02
+# CUDA 11.4.1           >= 470.57.02
 # CUDA 11.4.0           >= 470.42.01
 # CUDA 11.3.1           >= 465.19.01
 # CUDA 11.3.0           >= 465.19.01

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,26 @@
 FROM nvidia/cuda:11.4.2-devel-ubuntu20.04
 
 # CUDA version must be compatible with driver version of host:
-# via https://docs.nvidia.com/deploy/cuda-compatibility/#minor-version-compatibility
+#      via: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+# see also: https://cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install
+#           https://cloud.google.com/container-optimized-os/docs/release-notes
 #
 # CUDA Toolkit          Linux x86_64 Driver Version
 #--------------------------------------------------
-# CUDA 11.x             >= 450.80.02
+# CUDA 11.5             >= 495.29.05
+# CUDA 11.4             >= 470.82.01
+# CUDA 11.4             >= 470.57.02
+# CUDA 11.4             >= 470.57.02
+# CUDA 11.4.0           >= 470.42.01
+# CUDA 11.3.1           >= 465.19.01
+# CUDA 11.3.0           >= 465.19.01
+# CUDA 11.2.2           >= 460.32.03
+# CUDA 11.2.1           >= 460.32.03
+# CUDA 11.2.0           >= 460.27.03
+# CUDA 11.1.1           >= 455.32
+# CUDA 11.1             >= 455.23
+# CUDA 11.0.3           >= 450.51.06
+# CUDA 11.0.2           >= 450.51.05
 # CUDA 10.2             >= 440.33
 # CUDA 10.1             >= 418.39
 # CUDA 10.0 (10.0.130)  >= 410.48

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM nvidia/cuda:11.0.3-devel-ubuntu20.04
 # Note: The container-optimized OS (COS) images used to host dsub docker containers
 #       have NVIDIA driver versions that lag current versions. The nvidia/cuda baseimage
 #       baseimage above should use a CUDA version compatible with the driver in the 
-#       current COS image.
+#       current COS image. 
 #           see: https://cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install
 #                https://cloud.google.com/container-optimized-os/docs/release-notes
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,13 @@ FROM nvidia/cuda:11.0.3-devel-ubuntu20.04
 
 # CUDA version must be compatible with driver version of host:
 #      via: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
-# see also: https://cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install
-#           https://cloud.google.com/container-optimized-os/docs/release-notes
+#
+# Note: The container-optimized OS (COS) images used to host dsub docker containers
+#       have NVIDIA driver versions that lag current versions. The nvidia/cuda baseimage
+#       baseimage above should use a CUDA version compatible with the driver in the 
+#       current COS image.
+#           see: https://cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install
+#                https://cloud.google.com/container-optimized-os/docs/release-notes
 #
 # CUDA Toolkit          Linux x86_64 Driver Version
 #--------------------------------------------------
@@ -31,8 +36,6 @@ FROM nvidia/cuda:11.0.3-devel-ubuntu20.04
 # CUDA 8.0 (8.0.44)     >= 367.48
 # CUDA 7.5 (7.5.16)     >= 352.31
 # CUDA 7.0 (7.0.28)     >= 346.46
-#
-# As of 2019-02-26, driver version 396.37 is suggested
 
 LABEL maintainer "Daniel Park <dpark@broadinstitute.org>"
 LABEL maintainer_other "Christopher Tomkins-Tinch <tomkinsc@broadinstitute.org>"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ GPU-accelerated Docker images containing [BEAST](http://beast.community/about) a
 ## Instructions
 * (Follow the `dsub` instructions to [Get Started on Google Cloud](https://github.com/DataBiosphere/dsub#getting-started-on-google-cloud))
 * Install [dsub](https://github.com/DataBiosphere/dsub)
+* [Enable the required GCP APIs](https://console.cloud.google.com/flows/enableapi?apiid=lifesciences.googleapis.com,storage_component,compute_component&redirect=https://console.cloud.google.com)
 * Create an input XML for BEAST (via [BEAUTi](http://beast.community/beauti))
 * Transfer the XML file to a GS bucket
 * Call `dsub_beast.sh`:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Usage:
         Docker images have been built for several versions of BEAST.
         The Docker image to be used can be selected by the BEAST_VERSION environment variable.
         For example:
-          BEAST_VERSION='1.10.5pre' dsub_beast.sh gs://path/to/in.xml gcp-project-name num_gpus [beagle_order]
+          BEAST_VERSION='1.10.5pre_thorney_v0.1.1' dsub_beast.sh gs://path/to/in.xml gcp-project-name num_gpus [beagle_order]
         For available versions of BEAST, see the tags on Quay.io:
           https://quay.io/repository/broadinstitute/beast-beagle-cuda?tab=tags
         If BEAST_VERSION is not specified the 'latest' tag will be used.

--- a/dsub_beast.sh
+++ b/dsub_beast.sh
@@ -150,7 +150,7 @@ echo "DOCKER_IMAGE: ${DOCKER_IMAGE}${DOCKER_IMAGE_TAG}"
 echo "BEAST_EXTRA_ARGS:   ${BEAST_EXTRA_ARGS}"
 
 dsub \
-  --provider=google-v2 \
+  --provider=google-cls-v2 \
   --project "${GCP_PROJECT}" \
   --zone "us*" \
   --image "${DOCKER_IMAGE}${DOCKER_IMAGE_TAG}" \

--- a/dsub_beast.sh
+++ b/dsub_beast.sh
@@ -153,7 +153,6 @@ dsub \
   --provider=google-v2 \
   --project "${GCP_PROJECT}" \
   --zone "us*" \
-  --nvidia-driver-version "396.37" \
   --image "${DOCKER_IMAGE}${DOCKER_IMAGE_TAG}" \
   --input "INPUT_FILE=${IN_XML}" \
   --output "OUTPUT_FILES=${OUT_BUCKET}/*" \

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -10,17 +10,23 @@ echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 # Add some basics
 apt-get update
 #--no-install-recommends
+# See here for packages required to build beagle:
+#   https://github.com/beagle-dev/beagle-lib/wiki/LinuxInstallInstructions
+
 apt-get install -y -qq \
 	lsb-release ca-certificates wget rsync curl \
 	python-crcmod less nano vim git locales make \
 	dirmngr \
 	liblz4-tool pigz bzip2 lbzip2 zstd \
-	libtool autoconf g++-6 gcc-6 \
+	cmake build-essential autoconf automake libtool git pkg-config \
 	ant \
-	openjdk-8-jre openjdk-8-jdk
+	openjdk-11-jre openjdk-11-jdk
     #
 
 mkdir -p /usr/local/cuda/bin
+# debugging:
+ls -1 /usr/bin | grep "gcc"
+
 ln -s /usr/bin/gcc-6 /usr/local/cuda/bin/gcc
 ln -s /usr/bin/g++-6 /usr/local/cuda/bin/g++
 

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -15,7 +15,7 @@ apt-get update
 
 apt-get install -y -qq \
 	lsb-release ca-certificates wget rsync curl \
-	python-crcmod less nano vim git locales make \
+	less nano vim git locales make \
 	dirmngr \
 	liblz4-tool pigz bzip2 lbzip2 zstd \
 	cmake build-essential autoconf automake libtool git pkg-config \

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -25,10 +25,10 @@ apt-get install -y -qq \
 
 mkdir -p /usr/local/cuda/bin
 # debugging:
-ls -1 /usr/bin | grep "gcc"
+ls -lah /usr/bin | grep "gcc"
 
-ln -s /usr/bin/gcc-6 /usr/local/cuda/bin/gcc
-ln -s /usr/bin/g++-6 /usr/local/cuda/bin/g++
+ln -s /usr/bin/gcc-9 /usr/local/cuda/bin/gcc
+ln -s /usr/bin/g++-9 /usr/local/cuda/bin/g++
 
 # Auto-detect platform
 DEBIAN_PLATFORM="$(lsb_release -c -s)"

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -24,8 +24,6 @@ apt-get install -y -qq \
     #
 
 mkdir -p /usr/local/cuda/bin
-# debugging:
-ls -lah /usr/bin | grep "gcc"
 
 ln -s /usr/bin/gcc-9 /usr/local/cuda/bin/gcc
 ln -s /usr/bin/g++-9 /usr/local/cuda/bin/g++

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -35,7 +35,11 @@ DEBIAN_PLATFORM="$(lsb_release -c -s)"
 echo "Debian platform: $DEBIAN_PLATFORM"
 
 # Add source for gcloud sdk
-echo "deb http://packages.cloud.google.com/apt cloud-sdk-$DEBIAN_PLATFORM main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+echo "deb http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+# The line below is commented out since there is not a "focal" build of cloud-sdk in the apt repo (20.04); 
+#   remove the line above and uncomment below when available.
+# echo "deb http://packages.cloud.google.com/apt cloud-sdk-$DEBIAN_PLATFORM main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
 # Install gcloud and aws

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -10,9 +10,8 @@ cd /opt/docker
 #git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
 # localize beagle pinned to commit aee7aae with changes since v3.1.2 release
 git clone --depth=1 https://github.com/beagle-dev/beagle-lib.git
-git checkout aee7aae
-
 cd beagle-lib
+git checkout aee7aae
 
 mkdir build
 cd build

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -20,7 +20,8 @@ cd build
 #cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 #cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=true -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 # generic 64-bit cpu
-cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+#cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_CXX_FLAGS="-march=x86-64 -mtune=intel" -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_CXX_FLAGS="-march=haswell -mtune=intel" -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -25,6 +25,9 @@ ls -1 .
 echo "ls ./examples"
 ls -1 ./examples
 
+echo "ls ./examples/synthetictest"
+ls -1 ./examples/synthetictest
+
 echo "ls ../"
 ls -1 ../
 

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -4,6 +4,7 @@ set -e -o pipefail
 
 # report CPU info
 lscpu
+cat /proc/cpuinfo
 
 cd /opt/docker
 

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -7,7 +7,11 @@ nvcc --help
 cd /opt/docker
 
 # beagle 3.1.2, known working with beast 1.10.5pre
-git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
+#git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
+# localize beagle pinned to commit aee7aae with changes since v3.1.2 release
+git clone --depth=1 https://github.com/beagle-dev/beagle-lib.git
+git checkout aee7aae
+
 cd beagle-lib
 
 mkdir build

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -10,10 +10,8 @@ cd /opt/docker
 
 # beagle 3.1.2, known working with beast 1.10.5pre
 #git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
-# localize beagle pinned to commit aee7aae with changes since v3.1.2 release
-git clone --depth=1 https://github.com/beagle-dev/beagle-lib.git
+git clone --depth=1 --branch "v4.0.0" https://github.com/beagle-dev/beagle-lib.git
 cd beagle-lib
-git checkout aee7aae
 
 mkdir build
 cd build

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -10,13 +10,13 @@ cd /opt/docker
 # beagle 3.1.2, known working with beast 1.10.5pre
 #git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
 # localize beagle pinned to commit aee7aae with changes since v3.1.2 release
-git clone --depth=1 https://github.com/beagle-dev/beagle-lib.git
+git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
 cd beagle-lib
 git checkout aee7aae
 
 mkdir build
 cd build
-cmake -DBUILD_OPENCL=OFF -BEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -16,7 +16,10 @@ git checkout aee7aae
 
 mkdir build
 cd build
-cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+#cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+#cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=true -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+# generic 64-bit cpu
+cmake -DBUILD_OPENCL=OFF -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -18,11 +18,12 @@ cd build
 cmake -DBUILD_OPENCL=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
-echo "ls build"
+echo "ls ."
+pwd
 ls -lah .
 
-echo "ls examples/synthetictest"
-ls -lah ../examples/synthetictest
+echo "ls ../"
+ls -lah ../
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib
 

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -18,6 +18,12 @@ cd build
 cmake -DBUILD_OPENCL=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
+echo "ls build"
+ls -lah .
+
+echo "ls examples/synthetictest"
+ls -lah ../examples/synthetictest
+
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib
 
 examples/synthetictest/synthetictest

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -2,8 +2,6 @@
 
 set -e -o pipefail
 
-nvcc --help
-
 cd /opt/docker
 
 # beagle 3.1.2, known working with beast 1.10.5pre
@@ -18,25 +16,6 @@ cd build
 cmake -DBUILD_OPENCL=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
-pwd
-echo "ls ."
-ls -1 .
-
-echo "ls ./examples"
-ls -1 ./examples
-
-echo "ls ./examples/synthetictest"
-ls -1 ./examples/synthetictest
-
-echo "ls ../"
-ls -1 ../
-
-echo "ls ../examples/synthetictest"
-ls -1 ../examples/synthetictest
-
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib
 
 examples/synthetictest
-
-#examples/synthetictest/synthetictest
-#examples/tinytest/tinytest

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -10,10 +10,9 @@ cd /opt/docker
 git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
 cd beagle-lib
 
-./autogen.sh
-./configure --disable-sse --disable-march-native --prefix=/usr/local
-
-make
+mkdir build
+cd build
+cmake -DBUILD_OPENCL=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 make check
 

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -17,7 +17,6 @@ mkdir build
 cd build
 cmake -DBUILD_OPENCL=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
-make check
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib
 

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -10,7 +10,7 @@ cd /opt/docker
 # beagle 3.1.2, known working with beast 1.10.5pre
 #git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
 # localize beagle pinned to commit aee7aae with changes since v3.1.2 release
-git clone --depth=1 --branch="v3.1.2" https://github.com/beagle-dev/beagle-lib.git
+git clone --depth=1 https://github.com/beagle-dev/beagle-lib.git
 cd beagle-lib
 git checkout aee7aae
 

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -18,12 +18,18 @@ cd build
 cmake -DBUILD_OPENCL=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
-echo "ls ."
 pwd
-ls -lah .
+echo "ls ."
+ls -1 .
+
+echo "ls ./examples"
+ls -1 ./examples
 
 echo "ls ../"
-ls -lah ../
+ls -1 ../
+
+echo "ls ../examples/synthetictest"
+ls -1 ../examples/synthetictest
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib
 

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -19,7 +19,7 @@ cd build
 #cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 #cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=true -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 # generic 64-bit cpu
-cmake -DBUILD_OPENCL=OFF -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+cmake -DBUILD_OPENCL=OFF -DBEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_CXX_FLAGS="-march=x86-64" -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -2,6 +2,9 @@
 
 set -e -o pipefail
 
+# report CPU info
+lscpu
+
 cd /opt/docker
 
 # beagle 3.1.2, known working with beast 1.10.5pre
@@ -13,7 +16,7 @@ git checkout aee7aae
 
 mkdir build
 cd build
-cmake -DBUILD_OPENCL=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+cmake -DBUILD_OPENCL=OFF -BEAGLE_OPTIMIZE_FOR_NATIVE_ARCH=false -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
 make install
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -36,5 +36,7 @@ ls -1 ../examples/synthetictest
 
 ldconfig # LD_LIBRARY_PATH is also set in the Dockerfile to include /usr/local/lib
 
-examples/synthetictest/synthetictest
-examples/tinytest/tinytest
+examples/synthetictest
+
+#examples/synthetictest/synthetictest
+#examples/tinytest/tinytest

--- a/install-beagle.sh
+++ b/install-beagle.sh
@@ -2,6 +2,8 @@
 
 set -e -o pipefail
 
+nvcc --help
+
 cd /opt/docker
 
 # beagle 3.1.2, known working with beast 1.10.5pre

--- a/install-beast.sh
+++ b/install-beast.sh
@@ -8,6 +8,9 @@ wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v1.10.5pr
 tar -xzpf BEASTv${beast_version}.tgz
 rm BEASTv${beast_version}.tgz
 
+echo "ls -1"
+ls -1
+
 mv BEASTv${beast_version}/bin/* /usr/local/bin
 mv BEASTv${beast_version}/lib/* /usr/local/lib
 

--- a/install-beast.sh
+++ b/install-beast.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-beast_version="1.10.5pre_thorney_v0.1.1"
+beast_version="1.10.5pre_thorney_0.1.1"
 # uncomment when out of pre-release:
 #wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v${beast_version}/BEASTv${beast_version}.tgz
 wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v1.10.5pre_thorney_v0.1.1/BEASTv1.10.5pre_thorney_0.1.1.tgz -O BEASTv${beast_version}.tgz

--- a/install-beast.sh
+++ b/install-beast.sh
@@ -10,6 +10,8 @@ rm BEASTv${beast_version}.tgz
 
 echo "ls -1"
 ls -1
+echo "ls -1 BEASTv${beast_version}"
+ls -1 BEASTv${beast_version}
 
 mv BEASTv${beast_version}/bin/* /usr/local/bin
 mv BEASTv${beast_version}/lib/* /usr/local/lib

--- a/install-beast.sh
+++ b/install-beast.sh
@@ -8,11 +8,6 @@ wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v1.10.5pr
 tar -xzpf BEASTv${beast_version}.tgz
 rm BEASTv${beast_version}.tgz
 
-echo "ls -1"
-ls -1
-echo "ls -1 BEASTv${beast_version}"
-ls -1 BEASTv${beast_version}
-
 mv BEASTv${beast_version}/bin/* /usr/local/bin
 mv BEASTv${beast_version}/lib/* /usr/local/lib
 

--- a/install-beast.sh
+++ b/install-beast.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-beast_version="1.10.5pre"
+beast_version="1.10.5pre_thorney_v0.1.1"
 # uncomment when out of pre-release:
 #wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v${beast_version}/BEASTv${beast_version}.tgz
-wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v1.10.5pre1/BEASTv1.10.5pre.tgz -O BEASTv${beast_version}.tgz
+wget --quiet https://github.com/beast-dev/beast-mcmc/releases/download/v1.10.5pre_thorney_v0.1.1/BEASTv1.10.5pre_thorney_0.1.1.tgz -O BEASTv${beast_version}.tgz
 
 tar -xzpf BEASTv${beast_version}.tgz
 rm BEASTv${beast_version}.tgz

--- a/run_beast.sh
+++ b/run_beast.sh
@@ -21,7 +21,7 @@ cd $OUT_DIR
 # report beagle info including number of GPUs
 beast -beagle_info > "${OUTPUT_PREFIX}.out"
 # report CPU info
-lscpu >> "${OUTPUT_PREFIX}.out"
+lscpu | tee -a "${OUTPUT_PREFIX}.out"
 pwd 
 beast -beagle_multipartition off -beagle_GPU -beagle_cuda -beagle_double -beagle_scaling always -beagle_order ${BEAGLE_ORDER} ${BEAST_EXTRA_ARGS} ${INPUT_FILE} >> "${OUTPUT_PREFIX}.out"
 ls 

--- a/run_beast.sh
+++ b/run_beast.sh
@@ -18,7 +18,10 @@ fi
 
 pwd 
 cd $OUT_DIR
+# report beagle info including number of GPUs
 beast -beagle_info > "${OUTPUT_PREFIX}.out"
+# report CPU info
+lscpu >> "${OUTPUT_PREFIX}.out"
 pwd 
 beast -beagle_multipartition off -beagle_GPU -beagle_cuda -beagle_double -beagle_scaling always -beagle_order ${BEAGLE_ORDER} ${BEAST_EXTRA_ARGS} ${INPUT_FILE} >> "${OUTPUT_PREFIX}.out"
 ls 


### PR DESCRIPTION
update CUDA to 11.0.3 and Ubuntu to 20.04 (should be compatible with NVidia driver used by [latest COS](https://cloud.google.com/container-optimized-os/docs/release-notes)), update apt build toolchain dependencies in response to Ubuntu 20.04 upgrade. Migrate beagle build to CMake. Update BEAST to  BEASTv.1.10.5pre_thorney_v0.1.1 to match the version specified on the documentation page, "[Approaches for analyzing large phylogenetic datasets](https://beast.community/thorney_beast)"

=====================

remove dsub --nvidia-driver-version argument since it is deprecated and now ignored by the pipelines API; see:
https://github.com/DataBiosphere/dsub/commit/0421018a269d16f150a0b674aa38e9e18b5c2f0d

update to new google api, google-cls-v2
see: https://github.com/DataBiosphere/dsub#getting-started-on-google-cloud

Note: APIs must be enabled before use, which can be done here:
https://console.cloud.google.com/flows/enableapi?apiid=lifesciences.googleapis.com,storage_component,compute_component&redirect=https://console.cloud.google.com

update beast to 1.10.5pre_thorney_v0.1.1, to support features noted on the page "Approaches for analyzing large phylogenetic datasets"; see: https://beast.community/thorney_beast

update cuda baseimage to reflect latest driver version in current COS image

The nvidia driver version in the container-optimized OS host images lags the current versions.
see: https://github.com/DataBiosphere/dsub/issues/224
For the driver version in the current COS image, see:
https://cloud.google.com/container-optimized-os/docs/release-notes

update readme example for setting the BEAST version

update build toolchain packages

omit python-crcmod

do not pin google-cloud-sdk to specific debian version (since "focal" build for 20.04 is not in apt repo)

gcc 9

switch to CMake-based build as detailed in the current beagle build/install instructions:
https://github.com/beagle-dev/beagle-lib/wiki/LinuxInstallInstructions

localize more recent beagle code than 3.1.2 tag from 2018

remove deprecated "make check" call
